### PR TITLE
:bug: shopworld-List will no longer count duplicates

### DIFF
--- a/engine/Shopware/Controllers/Backend/Emotion.php
+++ b/engine/Shopware/Controllers/Backend/Emotion.php
@@ -88,7 +88,7 @@ class Shopware_Controllers_Backend_Emotion extends Shopware_Controllers_Backend_
         $statement = $query->execute();
         $emotions = $statement->fetchAll(PDO::FETCH_ASSOC);
 
-        $query->select('COUNT(emotions.id) as count')
+        $query->select('COUNT(DISTINCT emotions.id) as count')
             ->resetQueryPart('groupBy')
             ->resetQueryPart('orderBy')
             ->setFirstResult(0)


### PR DESCRIPTION
query-statement joins s_emotion with s_emotion_categories -> count will have duplicate entries of the same s_emotion.id
This will affect the listing count and the page navigator will stop working because Emotion.php's listAction() returns a bloated total count.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developers.shopware.com/contributing/contribution-guideline/).
-->

### 1. Why is this change necessary?
The **shopping-world listing** in the backend should include data provided by the Emotion.php's listAction().
This will return **data** and **total**, former being responsible for the **list output** and the latter being responsible for the **page navigation**.

The problem lies in the fact that the count query for **total** will list duplicates of the same shopping world due to the join with other tables. This will negatively affect the page navigation, making it seem like there are more shopping worlds than actually in the database.

I propose either a `->resetQueryPart('join')` for the count-query to disable joins which could bloat the count or more elegantly:

`Make the count statement distinct in concern to the s_emotion.id to truly avoid counting the same shopping worlds more than once.`


### 2. What does this change do, exactly?

Instead of counting emotions.id without any restrictions, we forbid the duplicate count of emotions.id just as the fetched data gets duplicates after the join.

### 3. Describe each step to reproduce the issue or behaviour.

* Create a shopping world
* See how the listAction() reponse will list that shopping world with a total of 1
* Add multiple categories to the same shopping world
* Realize how the total count is affected but the actual list of shopping world stays the same
* At a total count of +50, a second page will be made available - even though there is only a single shopping world

### 4. Please link to the relevant issues (if any).

/

### 5. Which documentation changes (if any) need to be made because of this PR?

/

### 6. Checklist

- ✅ I have done absolutely nothing to warrant the legitimacy of my pull request